### PR TITLE
Collection: Fix for php 8.1

### DIFF
--- a/src/CrowdinApiClient/Collection.php
+++ b/src/CrowdinApiClient/Collection.php
@@ -28,6 +28,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value is cast to an integer.
      * @since 5.1.0
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return sizeof($this->_items);
@@ -40,6 +41,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * <b>Traversable</b>
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new CollectionIterator($this->_items);
@@ -57,6 +59,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      * The return value will be casted to boolean if non-boolean was returned.
      * @since 5.0.0
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_items[$offset]);


### PR DESCRIPTION
PHP 8.1 throws a deprecation warning if the return type does not match here. I've opened an upstream issue so hopefully we can drop this fork at some point.

```
Error: During inheritance of IteratorAggregate: Uncaught Whoops\Exception\ErrorException: Return type of CrowdinApiClient\Collection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```